### PR TITLE
adds Tms.to_h, fixes test require.

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -527,6 +527,9 @@ module Benchmark
       [@label, @utime, @stime, @cutime, @cstime, @real]
     end
 
+    #
+    # Returns a hash containing the same data as `to_a`.
+    #
     def to_h
       {
         label:  @label,

--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -527,6 +527,17 @@ module Benchmark
       [@label, @utime, @stime, @cutime, @cstime, @real]
     end
 
+    def to_h
+      {
+        label:  @label,
+        utime:  @utime,
+        stime:  @stime,
+        cutime: @cutime,
+        cstime: @cstime,
+        real:   @real
+      }
+    end
+
     protected
 
     #

--- a/test/benchmark/test_benchmark.rb
+++ b/test/benchmark/test_benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
-require 'benchmark'
+require_relative '../../lib/benchmark'
 
 class TestBenchmark < Test::Unit::TestCase
   BENCH_FOR_TIMES_UPTO = lambda do |x|
@@ -154,5 +154,13 @@ BENCH
     sleeptime = 1.0
     realtime = Benchmark.realtime { sleep sleeptime }
     assert_operator sleeptime, :<, realtime
+  end
+
+  def test_tms_to_h
+    tms = Benchmark::Tms.new(1.1, 2.2, 3.3, 4.4, 5.5, 'my label')
+    expected_hash = {
+      utime: 1.1, stime: 2.2, cutime: 3.3, cstime: 4.4, real: 5.5, label: 'my label'
+    }
+    assert_equal(expected_hash, tms.to_h)
   end
 end

--- a/test/benchmark/test_benchmark.rb
+++ b/test/benchmark/test_benchmark.rb
@@ -156,6 +156,7 @@ BENCH
     assert_operator sleeptime, :<, realtime
   end
 
+  # Test that `to_h` returns a hash with the expected data.
   def test_tms_to_h
     tms = Benchmark::Tms.new(1.1, 2.2, 3.3, 4.4, 5.5, 'my label')
     expected_hash = {

--- a/test/benchmark/test_benchmark.rb
+++ b/test/benchmark/test_benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'test/unit'
-require_relative '../../lib/benchmark'
+require 'benchmark'
 
 class TestBenchmark < Test::Unit::TestCase
   BENCH_FOR_TIMES_UPTO = lambda do |x|


### PR DESCRIPTION
Adds a `to_h` method to Benchmark::Tms.

Fixes the test file's `require` to load the code in the modified benchmark.rb instead of the Ruby distribution.

