### PR TITLE
Add comment about terminating newline in captions; fix test method name.

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -128,6 +128,9 @@ module Benchmark
   # benchmark tests. Reserves +label_width+ leading spaces for
   # labels on each line. Prints +caption+ at the top of the
   # report, and uses +format+ to format each line.
+  # (Note: +caption+ must contain a terminating newline character,
+  # see the default Benchmark::Tms::CAPTION for an example.)
+  #
   # Returns an array of Benchmark::Tms objects.
   #
   # If the block returns an array of

--- a/test/benchmark/test_benchmark.rb
+++ b/test/benchmark/test_benchmark.rb
@@ -71,7 +71,7 @@ third  --time--   --time--   --time-- (  --time--)
 BENCH
   end
 
-  def test_benchmark_makes_extra_calcultations_with_an_Array_at_the_end_of_the_benchmark_and_show_the_result
+  def test_benchmark_makes_extra_calculations_with_an_Array_at_the_end_of_the_benchmark_and_show_the_result
     assert_equal(BENCHMARK_OUTPUT_WITH_TOTAL_AVG,
       capture_bench_output(:benchmark,
         Benchmark::CAPTION, 7,


### PR DESCRIPTION
This is a much trimmed-down PR as per @jeremyevans ' direction at https://github.com/ruby/benchmark/pull/7, consisting of a clarifying comment and a spelling correction of a test method name.