### PR TITLE
Document that default FORMAT includes total time

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -491,7 +491,7 @@ module Benchmark
     # accepts the following extensions:
     #
     # <tt>%u</tt>::     Replaced by the user CPU time, as reported by Tms#utime.
-    # <tt>%y</tt>::     Replaced by the system CPU time, as reported by #stime (Mnemonic: y of "s*y*stem")
+    # <tt>%y</tt>::     Replaced by the system CPU time, as reported by Tms#stime (Mnemonic: y of "s*y*stem")
     # <tt>%U</tt>::     Replaced by the children's user CPU time, as reported by Tms#cutime
     # <tt>%Y</tt>::     Replaced by the children's system CPU time, as reported by Tms#cstime
     # <tt>%t</tt>::     Replaced by the total CPU time, as reported by Tms#total
@@ -499,7 +499,7 @@ module Benchmark
     # <tt>%n</tt>::     Replaced by the label string, as reported by Tms#label (Mnemonic: n of "*n*ame")
     #
     # If +format+ is not given, FORMAT is used as default value, detailing the
-    # user, system and real elapsed time.
+    # user, system, total and real elapsed time.
     #
     def format(format = nil, *args)
       str = (format || FORMAT).dup


### PR DESCRIPTION
The default `FORMAT` string is currently:

`"%10.6u %10.6y %10.6t %10.6r\n"`

which represents user time, system time, **total time**, and elapsed real time, respectively.

I've updated the documentation to reflect this reality.