### PR TITLE
Bugfix for Tms#add! not updating @total

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -455,6 +455,7 @@ module Benchmark
       @cutime = cutime + t.cutime
       @cstime = cstime + t.cstime
       @real   = real + t.real
+      @total  = total + t.total
       self
     end
 

--- a/test/benchmark/test_benchmark.rb
+++ b/test/benchmark/test_benchmark.rb
@@ -150,6 +150,15 @@ BENCH
     assert_not_equal(0, t.real)
   end
 
+  # TODO: Consider combining with the above test
+  def test_add_in_place
+    t = Benchmark::Tms.new
+    assert_equal(0, t.total)
+    
+    t.add! { 1000.times do   ; '1'; end }
+    assert_not_equal(0, t.total)
+  end
+
   def test_realtime_output
     sleeptime = 1.0
     realtime = Benchmark.realtime { sleep sleeptime }


### PR DESCRIPTION
Because the `total` instance variable only updates in `initialize`, it does not reflect the correct value when `add!` is called.  This fixes the problem.

A test case is provided to show the bug/fix.

A more robust solution would be to use a `total` method instead to return the calculated value.  It may be worth checking if such a solution is generally faster than doing the calculation every time a Tms object is created/updated.  Benchmark the benchmarking! :-)