### PR TITLE
Set required_ruby_version = ">= 2.1.0"

### DIFF
--- a/benchmark.gemspec
+++ b/benchmark.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/benchmark"
   spec.licenses       = ["Ruby", "BSD-2-Clause"]
 
+  spec.required_ruby_version = ">= 2.1.0"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 


### PR DESCRIPTION
`Process.clock_gettime` only works since 2.1