### PR TITLE
Improve docs for Benchmark.realtime

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -307,6 +307,7 @@ module Benchmark
 
   #
   # Returns the elapsed real time used to execute the given block.
+  # The unit of time is seconds.
   #
   def realtime # :yield:
     r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -309,6 +309,9 @@ module Benchmark
   # Returns the elapsed real time used to execute the given block.
   # The unit of time is seconds.
   #
+  #       Benchmark.realtime { "a" * 1_000_000_000 }
+  #       #=> 0.5098029999935534
+  #
   def realtime # :yield:
     r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     yield


### PR DESCRIPTION
Reopening this PR from ruby/ruby here: https://github.com/ruby/ruby/pull/11706

---

The documentation for `Benchmark.realtime` doesn't make it clear what unit is being used. I've updated the docs to specify that it uses seconds. The module level docs do mention that Benchmark.measure returns seconds, but it is easy to miss when looking at the method docs in isolation.

Rails has recently deprecated the `Benchmark.ms` monkeypatch (https://github.com/rails/rails/pull/52746), which means there might be more people using this in Rails app, and clarifying the unit here will make it less confusing to switch to this.

In addition, I have also added an example for the method.