### PR TITLE
Monthly updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'


### PR DESCRIPTION
@hsbt Would you be OK with this change?

I think dependabot updates cause a lot of noise ([in commits](https://github.com/ruby/benchmark/commits/master/) and in emails/notifications), so monthly seems a good alternative to reduce noise.